### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
     <strong>An MCP server for interacting with Open eClass platform instances, with specific support for UoA's SSO authentication system. </strong>
 </p>
 
+<a href="https://glama.ai/mcp/servers/@sdi2200262/eclass-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sdi2200262/eclass-mcp-server/badge" alt="eClass Server MCP server" />
+</a>
 
 <p aling="center">
     <img src="assets/example.png" alt="Example Usecase">
@@ -12,7 +15,6 @@
 <p aling="center">
     <strong>This server enables AI agents to authenticate with eClass, retrieve course information, and perform basic operations on the platform. </strong>
 </p>
-
 
 ## Features
 


### PR DESCRIPTION
This PR adds a badge for the [eClass MCP Server](https://glama.ai/mcp/servers/@sdi2200262/eclass-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@sdi2200262/eclass-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@sdi2200262/eclass-mcp-server/badge" alt="eClass Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.